### PR TITLE
NPM: Use exact version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@coding-blocks/motley": "^0.4.3"
+    "@coding-blocks/motley": "0.4.3"
   }
 }


### PR DESCRIPTION
This should prevent any unexpected changes to dependencies, which can affect the ability reproduce builds.

Instead of using latest, you could use something like Renovate. Renovate Automatically updates npm, yarn, meteor, docker and meteor dependencies via Pull Requests. And is free for open-source projects.